### PR TITLE
Fixed iVerilog error on the priority/round-robin arbiter

### DIFF
--- a/Priority_Arbiter.html
+++ b/Priority_Arbiter.html
@@ -36,7 +36,7 @@ module Priority_Arbiter
 )
 (
     input   wire    [WORD_WIDTH-1:0]    requests,
-    output  reg     [WORD_WIDTH-1:0]    grant
+    output  wire    [WORD_WIDTH-1:0]    grant
 );
 
     Bitmask_Isolate_Rightmost_1_Bit

--- a/Priority_Arbiter.v
+++ b/Priority_Arbiter.v
@@ -28,7 +28,7 @@ module Priority_Arbiter
 )
 (
     input   wire    [WORD_WIDTH-1:0]    requests,
-    output  reg     [WORD_WIDTH-1:0]    grant
+    output  wire    [WORD_WIDTH-1:0]    grant
 );
 
     Bitmask_Isolate_Rightmost_1_Bit


### PR DESCRIPTION
An iverilog error because reg was used instead of wire in an output connected to an instantiated module.