### PR TITLE
fix bug

### DIFF
--- a/Adder_Subtractor_Binary_Multiprecision.html
+++ b/Adder_Subtractor_Binary_Multiprecision.html
@@ -317,7 +317,7 @@ module <a href="./Adder_Subtractor_Binary_Multiprecision.html">Adder_Subtractor_
     )
     step_adder
     (
-        .add_sub    (1'b0), // 0/1 -> A+B/A-B
+        .add_sub    (add_sub), // 0/1 -> A+B/A-B
         .carry_in   (step_carry_in),
         .A          (step_A),
         .B          (step_B),

--- a/Adder_Subtractor_Binary_Multiprecision.v
+++ b/Adder_Subtractor_Binary_Multiprecision.v
@@ -293,7 +293,7 @@ module Adder_Subtractor_Binary_Multiprecision
     )
     step_adder
     (
-        .add_sub    (1'b0), // 0/1 -> A+B/A-B
+        .add_sub    (add_sub), // 0/1 -> A+B/A-B
         .carry_in   (step_carry_in),
         .A          (step_A),
         .B          (step_B),


### PR DESCRIPTION
The `Adder_Subtractor_Binary_Multiprecision` module has an input [add_sub](https://github.com/laforest/FPGADesignElements/blob/2df9f8f8e535c09f8f93b4dc1633e64f83f4dbf4/Adder_Subtractor_Binary_Multiprecision.v#L49),
So the `Adder_Subtractor_Binary` instance inside it should set its `add_sub` using the outer module input.

