### PR TITLE
Fix for Arbiter_Priority interrupting every grant at the next clock.

### DIFF
--- a/Arbiter_Priority.html
+++ b/Arbiter_Priority.html
@@ -76,9 +76,10 @@ module <a href="./Arbiter_Priority.html">Arbiter_Priority</a>
 );
 </pre>
 
-<p>First we filter the requests, masking off any externally disabled requestst
- (<code>requests_mask</code> bit is 0), or only allowing the currently granted request
- (if any).</p>
+<p>If the request granted on the previous clock cycle is still active, hold it.
+ Else, filter the requests, masking off any externally disabled requests
+ (<code>requests_mask</code> bit is 0).
+ Note that a granted request cannot be interrupted by clearing its mask bit. </p>
 
 <pre>
     localparam INPUT_ZERO = {INPUT_COUNT{1'b0}};
@@ -86,7 +87,7 @@ module <a href="./Arbiter_Priority.html">Arbiter_Priority</a>
     reg  [INPUT_COUNT-1:0] requests_masked = INPUT_ZERO;
 
     always @(*) begin
-        requests_masked = requests & requests_mask & ~grant_previous;
+        requests_masked = ((requests & grant_previous) != INPUT_ZERO) ? grant_previous : (requests & requests_mask);
     end
 </pre>
 

--- a/Arbiter_Priority.v
+++ b/Arbiter_Priority.v
@@ -69,16 +69,17 @@ module Arbiter_Priority
     output  wire    [INPUT_COUNT-1:0]   grant
 );
 
-// First we filter the requests, masking off any externally disabled requestst
-// (`requests_mask` bit is 0), or only allowing the currently granted request
-// (if any).
+// If the request granted on the previous clock cycle is still active, hold it.
+// Else, filter the requests, masking off any externally disabled requests
+// (`requests_mask` bit is 0).
+// Note that a granted request cannot be interrupted by clearing its mask bit. 
 
     localparam INPUT_ZERO = {INPUT_COUNT{1'b0}};
 
     reg  [INPUT_COUNT-1:0] requests_masked = INPUT_ZERO;
 
     always @(*) begin
-        requests_masked = requests & requests_mask & ~grant_previous;
+        requests_masked = ((requests & grant_previous) != INPUT_ZERO) ? grant_previous : (requests & requests_mask);
     end
 
 // Then, from the remaining requests, we further mask out all but the highest


### PR DESCRIPTION
Before the fix, Arbiter_Priority would only hold a granted request for one clock cyle and then interrupt it:
- With no active requests, an all-zero grant is output (correct).
- With a single active request , output alternates between granting the request and al all-zero grant.
- With multiple active requests, output alternates between the two highest-priority requests.

With this fix, a granted request is held until the request is released.